### PR TITLE
Add some tests and fix logic in ExternalFileDirectorySecondaryStorageInspector

### DIFF
--- a/demo/src/main/java/com/novoda/storagepathfinder/demo/LandingActivity.java
+++ b/demo/src/main/java/com/novoda/storagepathfinder/demo/LandingActivity.java
@@ -5,9 +5,10 @@ import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 
+import com.novoda.storagepathfinder.AndroidDeviceStorageInspector;
 import com.novoda.storagepathfinder.StoragePath;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 
 public class LandingActivity extends AppCompatActivity {
@@ -23,7 +24,14 @@ public class LandingActivity extends AppCompatActivity {
 
         assetCloner = DemoDependenciesFactory.createAssetCloner(getApplicationContext());
 
-        List<StoragePath> deviceStoragePaths = Collections.emptyList(); // TODO use the inspector :D
+        AndroidDeviceStorageInspector storageInspector = DemoDependenciesFactory.createStorageInspector(getApplicationContext());
+
+        List<StoragePath> deviceStoragePaths = new ArrayList<>(4);
+
+        deviceStoragePaths.add(storageInspector.getPrimaryStorageBasePath());
+        deviceStoragePaths.add(storageInspector.getPrimaryStorageApplicationPath());
+        deviceStoragePaths.addAll(storageInspector.getSecondaryStorageBasePath());
+        deviceStoragePaths.addAll(storageInspector.getSecondaryStorageApplicationPath());
 
         RecyclerView recyclerView = findViewById(R.id.device_storage_roots);
         recyclerView.setLayoutManager(new LinearLayoutManager(getApplicationContext()));

--- a/demo/src/main/java/com/novoda/storagepathfinder/demo/LandingActivity.java
+++ b/demo/src/main/java/com/novoda/storagepathfinder/demo/LandingActivity.java
@@ -26,7 +26,7 @@ public class LandingActivity extends AppCompatActivity {
 
         AndroidDeviceStorageInspector storageInspector = DemoDependenciesFactory.createStorageInspector(getApplicationContext());
 
-        List<StoragePath> deviceStoragePaths = new ArrayList<>(4);
+        List<StoragePath> deviceStoragePaths = new ArrayList<>();
 
         deviceStoragePaths.add(storageInspector.getPrimaryStorageBasePath());
         deviceStoragePaths.add(storageInspector.getPrimaryStorageApplicationPath());

--- a/library/src/main/java/com/novoda/storagepathfinder/ExternalFileDirectoryInspector.java
+++ b/library/src/main/java/com/novoda/storagepathfinder/ExternalFileDirectoryInspector.java
@@ -89,9 +89,10 @@ public class ExternalFileDirectoryInspector implements SecondaryDeviceStorageIns
     }
 
     private boolean isValidPathForSecondaryStorage(String absolutePath, Filter base) {
+        String pathToCompare = absolutePath;
         if (base == Filter.APPLICATION) {
-            absolutePath = getDirectoryPathAboveTheAndroidFolderFrom(new File(absolutePath));
+            pathToCompare = getDirectoryPathAboveTheAndroidFolderFrom(new File(absolutePath));
         }
-        return !absolutePath.isEmpty() && !absolutePath.equals(primaryStoragePath);
+        return !pathToCompare.isEmpty() && !pathToCompare.equals(primaryStoragePath);
     }
 }

--- a/library/src/main/java/com/novoda/storagepathfinder/ExternalFileDirectoryInspector.java
+++ b/library/src/main/java/com/novoda/storagepathfinder/ExternalFileDirectoryInspector.java
@@ -76,7 +76,7 @@ public class ExternalFileDirectoryInspector implements SecondaryDeviceStorageIns
             if (base.equals(Filter.APPLICATION)) {
                 path = file.getAbsolutePath();
             }
-            if (isValidPathForSecondaryStorage(path)) {
+            if (isValidPathForSecondaryStorage(path, base)) {
                 storageRoots.add(DeviceStoragePath.create(path, SECONDARY));
             }
         }
@@ -88,7 +88,10 @@ public class ExternalFileDirectoryInspector implements SecondaryDeviceStorageIns
         return path == null ? "" : path;
     }
 
-    private boolean isValidPathForSecondaryStorage(String absolutePath) {
+    private boolean isValidPathForSecondaryStorage(String absolutePath, Filter base) {
+        if (base == Filter.APPLICATION) {
+            absolutePath = getDirectoryPathAboveTheAndroidFolderFrom(new File(absolutePath));
+        }
         return !absolutePath.isEmpty() && !absolutePath.equals(primaryStoragePath);
     }
 }

--- a/library/src/test/java/com/novoda/storagepathfinder/ExternalFileDirectoryInspectorTest.java
+++ b/library/src/test/java/com/novoda/storagepathfinder/ExternalFileDirectoryInspectorTest.java
@@ -9,12 +9,14 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.novoda.storagepathfinder.StoragePath.Type.PRIMARY;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 public class ExternalFileDirectoryInspectorTest {
 
-    private static final String PRIMARY_STORAGE_BASE_PATH = "/primary-storage-base-path";
+    private static final String PRIMARY_STORAGE_BASE_PATH_STRING = "/primary-storage-base-path";
+    private static final StoragePath PRIMARY_STORAGE_BASE_PATH = DeviceStoragePath.create(PRIMARY_STORAGE_BASE_PATH_STRING, PRIMARY);
     private static final StoragePath.Type SECONDARY = StoragePath.Type.SECONDARY;
     private static final StoragePath SECONDARY_BATH_PATH_1 = DeviceStoragePath.create("secondary-base-path-1", SECONDARY);
     private static final StoragePath SECONDARY_APPLICATION_PATH_1 = DeviceStoragePath.create("secondary-appplication-path-1", SECONDARY);
@@ -26,13 +28,13 @@ public class ExternalFileDirectoryInspectorTest {
 
     @Before
     public void setUp() {
-        inspector = new ExternalFileDirectoryInspector(context, deviceFeatures, PRIMARY_STORAGE_BASE_PATH);
+        inspector = new ExternalFileDirectoryInspector(context, deviceFeatures, PRIMARY_STORAGE_BASE_PATH_STRING);
     }
 
     @Test
-    public void returnsSecondaryStorageBasePathWhenFileDirectoriesAreAvailable() {
+    public void returnsBasePath_whenDeviceHasSecondaryStorage_andFileDirectoriesAreAvailable() {
         given(deviceFeatures.canReportExternalFileDirectories()).willReturn(true);
-        givenExternalFileDirectoriesWillReturnPaths(SECONDARY_BATH_PATH_1);
+        givenExternalFileDirectoriesWillReturnPaths(PRIMARY_STORAGE_BASE_PATH, SECONDARY_BATH_PATH_1);
 
         List<StoragePath> storagePaths = inspector.getSecondaryDeviceStorageBasePaths();
 
@@ -41,9 +43,9 @@ public class ExternalFileDirectoryInspectorTest {
     }
 
     @Test
-    public void returnsNoSecondaryStorageBasePathsWhenFileDirectoriesAreNotAvailable() {
+    public void returnsNoBasePaths_whenDeviceHasSecondaryStorage_andFileDirectoriesAreNotAvailable() {
         given(deviceFeatures.canReportExternalFileDirectories()).willReturn(false);
-        givenExternalFileDirectoriesWillReturnPaths(SECONDARY_BATH_PATH_1);
+        givenExternalFileDirectoriesWillReturnPaths(PRIMARY_STORAGE_BASE_PATH, SECONDARY_BATH_PATH_1);
 
         List<StoragePath> storagePaths = inspector.getSecondaryDeviceStorageBasePaths();
 
@@ -51,9 +53,9 @@ public class ExternalFileDirectoryInspectorTest {
     }
 
     @Test
-    public void returnsSecondaryStorageApplicationPathWhenFileDirectoriesAreAvailable() {
+    public void returnsApplicationPath_whenDeviceHasSecondaryStorage_andFileDirectoriesAreAvailable() {
         given(deviceFeatures.canReportExternalFileDirectories()).willReturn(true);
-        givenExternalFileDirectoriesWillReturnPaths(SECONDARY_APPLICATION_PATH_1);
+        givenExternalFileDirectoriesWillReturnPaths(PRIMARY_STORAGE_BASE_PATH, SECONDARY_APPLICATION_PATH_1);
 
         List<StoragePath> storagePaths = inspector.getSecondaryDeviceStorageApplicationPaths();
 
@@ -62,11 +64,31 @@ public class ExternalFileDirectoryInspectorTest {
     }
 
     @Test
-    public void returnsNoSecondaryStorageApplicationPathsWhenFileDirectoriesAreNotAvailable() {
+    public void returnsNoApplicationPaths_whenDeviceHasSecondaryStorage_andFileDirectoriesAreNotAvailable() {
         given(deviceFeatures.canReportExternalFileDirectories()).willReturn(false);
-        givenExternalFileDirectoriesWillReturnPaths(SECONDARY_APPLICATION_PATH_1);
+        givenExternalFileDirectoriesWillReturnPaths(PRIMARY_STORAGE_BASE_PATH, SECONDARY_APPLICATION_PATH_1);
 
         List<StoragePath> storagePaths = inspector.getSecondaryDeviceStorageApplicationPaths();
+
+        assertThat(storagePaths.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void returnsNoApplicationPaths_whenDeviceHasNoSecondaryStorage_andFileDirectoriesAreAvailable() {
+        given(deviceFeatures.canReportExternalFileDirectories()).willReturn(true);
+        givenExternalFileDirectoriesWillReturnPaths(PRIMARY_STORAGE_BASE_PATH);
+
+        List<StoragePath> storagePaths = inspector.getSecondaryDeviceStorageApplicationPaths();
+
+        assertThat(storagePaths.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void returnsNoBasePaths_whenDeviceHasNoSecondaryStorage_andFileDirectoriesAreAvailable() {
+        given(deviceFeatures.canReportExternalFileDirectories()).willReturn(true);
+        givenExternalFileDirectoriesWillReturnPaths(PRIMARY_STORAGE_BASE_PATH);
+
+        List<StoragePath> storagePaths = inspector.getSecondaryDeviceStorageBasePaths();
 
         assertThat(storagePaths.size()).isEqualTo(0);
     }


### PR DESCRIPTION
## Summary

When I added the 4 paths into the demo to be displayed, I noticed an error in the logic of the External File Directory Inspector. 

If you were getting the Application Path for secondary storage, and you have no secondary storage, it would return a path, and that path would be the primary storage. 

There was a  missing part of the logic for comparing the paths the FileDirectories return, and it was failing to identify the primary path to filter out in this case. 

I have done the minimum changes to fix the logic, and its not neat I know, but I am going to refactor the whole class in a coming PR, after I finish the demo. 
The important part is the logic works now, and the unit tests cover it properly.

## Testing
Added tests to cover the fix to the logic, and update the other tests to be more correct.

## Notes
Refactoring for this class will come later, so its not meant to be clean 💃 