### PR TITLE
Update the demo with more information

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ buildscript {
     repositories {
         jcenter()
         google()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.3'
@@ -24,6 +25,7 @@ subprojects {
     repositories {
         google()
         jcenter()
+        mavenCentral()
     }
 
     apply from: teamPropsFile('static-analysis.gradle')

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -31,4 +31,5 @@ dependencies {
     implementation 'com.android.support:recyclerview-v7:27.1.1'
     implementation 'com.android.support:cardview-v7:27.1.1'
     implementation 'com.android.support.constraint:constraint-layout:1.1.2'
+    implementation 'commons-io:commons-io:2.4'
 }

--- a/demo/src/main/AndroidManifest.xml
+++ b/demo/src/main/AndroidManifest.xml
@@ -3,6 +3,9 @@
   xmlns:tools="http://schemas.android.com/tools"
   package="com.novoda.storagepathfinder.demo">
 
+  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+
   <application
     android:allowBackup="false"
     android:icon="@mipmap/ic_launcher"

--- a/demo/src/main/java/com/novoda/storagepathfinder/demo/StoragePathViewHolder.java
+++ b/demo/src/main/java/com/novoda/storagepathfinder/demo/StoragePathViewHolder.java
@@ -96,15 +96,19 @@ class StoragePathViewHolder extends RecyclerView.ViewHolder {
 
     private String getSizeOf(StoragePath deviceStoragePath) {
         File pathAsFile = deviceStoragePath.getPathAsFile();
-
         long sizeOfDirectory = FileUtils.sizeOfDirectory(pathAsFile);
-        if (blockSizeCalculationsAreAvailable()) {
-            if (deviceStoragePath.getType() == PRIMARY && sizeOfDirectory == 0) {
-                sizeOfDirectory = getUsedSizeOf(deviceStoragePath);
-            }
+        if (sizeOfDirectory == 0 && deviceStoragePath.getType() == PRIMARY) {
+            sizeOfDirectory = getSizeFromBlockCalculations(deviceStoragePath);
         }
-
         return byteCountToDisplaySize(sizeOfDirectory);
+    }
+
+    private long getSizeFromBlockCalculations(StoragePath deviceStoragePath) {
+        if (blockSizeCalculationsAreAvailable()) {
+            return getUsedSizeOf(deviceStoragePath);
+        } else {
+            return 0;
+        }
     }
 
     @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)

--- a/demo/src/main/java/com/novoda/storagepathfinder/demo/StoragePathViewHolder.java
+++ b/demo/src/main/java/com/novoda/storagepathfinder/demo/StoragePathViewHolder.java
@@ -1,25 +1,141 @@
 package com.novoda.storagepathfinder.demo;
 
+import android.os.Build;
+import android.os.Environment;
+import android.os.StatFs;
+import android.support.annotation.RequiresApi;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.widget.TextView;
 
 import com.novoda.storagepathfinder.StoragePath;
 
+import java.io.File;
+
+import org.apache.commons.io.FileUtils;
+
+import static android.os.Build.VERSION.SDK_INT;
+import static com.novoda.storagepathfinder.StoragePath.Type.PRIMARY;
+import static com.novoda.storagepathfinder.StoragePath.Type.SECONDARY;
+import static org.apache.commons.io.FileUtils.byteCountToDisplaySize;
+
 class StoragePathViewHolder extends RecyclerView.ViewHolder {
 
-    private final TextView absolutePath;
+    private final TextView absolutePathView;
+    private final TextView pathTypeView;
     private final View addFile;
+    private final TextView pathUsedSizeView;
+    private final TextView pathAvailableSizeView;
+    private final TextView pathTotalSizeView;
+    private final TextView permissionsView;
+    private final TextView stateView;
 
     StoragePathViewHolder(View root) {
         super(root);
-        absolutePath = root.findViewById(R.id.device_storage_root);
+        pathTypeView = root.findViewById(R.id.device_storage_root_type);
+        absolutePathView = root.findViewById(R.id.device_storage_root);
+        pathUsedSizeView = root.findViewById(R.id.device_storage_root_used_size);
+        pathAvailableSizeView = root.findViewById(R.id.device_storage_root_available_size);
+        pathTotalSizeView = root.findViewById(R.id.device_storage_root_total_size);
+        permissionsView = root.findViewById(R.id.device_storage_root_permissions);
+        stateView = root.findViewById(R.id.device_storage_root_state);
         addFile = root.findViewById(R.id.add_file);
     }
 
     void bind(StoragePath deviceStoragePath, Listener listener) {
-        absolutePath.setText(deviceStoragePath.getPathAsString());
+        String typeText = "Type: " + deviceStoragePath.getType();
+        pathTypeView.setText(typeText);
+
+        String pathText = "Path: " + deviceStoragePath.getPathAsString();
+        absolutePathView.setText(pathText);
+
+        String sizeUsedText = "Storage Used: " + getSizeOf(deviceStoragePath);
+        pathUsedSizeView.setText(sizeUsedText);
+
+        long freeSpaceOfPath = deviceStoragePath.getPathAsFile().getFreeSpace();
+        String sizeAvailableText = "Storage Available: " + byteCountToDisplaySize(freeSpaceOfPath);
+        pathAvailableSizeView.setText(sizeAvailableText);
+
+        long totalSpaceOfPath = deviceStoragePath.getPathAsFile().getTotalSpace();
+        String sizeTotalText = "Storage Total: " + byteCountToDisplaySize(totalSpaceOfPath);
+        pathTotalSizeView.setText(sizeTotalText);
+
+        String canRead = String.valueOf(deviceStoragePath.getPathAsFile().canRead());
+        String canWrite = String.valueOf(deviceStoragePath.getPathAsFile().canWrite());
+        String permissionsText = "Permissions: Read:" + canRead + " | Write:" + canWrite;
+        permissionsView.setText(permissionsText);
+
+        String stateText = getStateFor(deviceStoragePath);
+        stateView.setText(stateText);
+
         addFile.setOnClickListener(v -> listener.onAddFileClickedFor(deviceStoragePath));
+    }
+
+    private String getStateFor(StoragePath deviceStoragePath) {
+        StoragePath.Type type = deviceStoragePath.getType();
+
+        String state = "";
+        String removable = "unknown";
+        String emulated = "unknown";
+
+        if (type.equals(PRIMARY)) {
+            state = Environment.getExternalStorageState();
+            removable = String.valueOf(Environment.isExternalStorageRemovable());
+            emulated = String.valueOf(Environment.isExternalStorageEmulated());
+        }
+
+        if (parameterisedExternalStorageEnvironmentCallsAreAvailable() && type.equals(SECONDARY)) {
+            File pathAsFile = deviceStoragePath.getPathAsFile();
+            state = Environment.getExternalStorageState(pathAsFile);
+            removable = String.valueOf(Environment.isExternalStorageRemovable(pathAsFile));
+            emulated = String.valueOf(Environment.isExternalStorageEmulated(pathAsFile));
+        }
+
+        return "State: " + state + " | Removable:" + removable + " | Emulated:" + emulated;
+    }
+
+    private String getSizeOf(StoragePath deviceStoragePath) {
+        File pathAsFile = deviceStoragePath.getPathAsFile();
+
+        long sizeOfDirectory = FileUtils.sizeOfDirectory(pathAsFile);
+        if (blockSizeCalculationsAreAvailable()) {
+            if (deviceStoragePath.getType() == PRIMARY && sizeOfDirectory == 0) {
+                sizeOfDirectory = getUsedSizeOf(deviceStoragePath);
+            }
+        }
+
+        return byteCountToDisplaySize(sizeOfDirectory);
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)
+    private long getUsedSizeOf(StoragePath deviceStoragePath) {
+        long totalSize = getTotalSizeOf(deviceStoragePath);
+        long availableSize = getAvailableSizeOf(deviceStoragePath);
+        return totalSize - availableSize;
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)
+    private long getTotalSizeOf(StoragePath deviceStoragePath) {
+        StatFs stat = new StatFs(deviceStoragePath.getPathAsString());
+        long blockSize = stat.getBlockSizeLong();
+        long totalBlocks = stat.getBlockCountLong();
+        return totalBlocks * blockSize;
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)
+    private long getAvailableSizeOf(StoragePath deviceStoragePath) {
+        StatFs stat = new StatFs(deviceStoragePath.getPathAsString());
+        long blockSize = stat.getBlockSizeLong();
+        long availableBlocks = stat.getAvailableBlocksLong();
+        return availableBlocks * blockSize;
+    }
+
+    private boolean blockSizeCalculationsAreAvailable() {
+        return SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2;
+    }
+
+    private boolean parameterisedExternalStorageEnvironmentCallsAreAvailable() {
+        return SDK_INT >= Build.VERSION_CODES.LOLLIPOP;
     }
 
     interface Listener {

--- a/demo/src/main/res/layout/include_device_storage_root.xml
+++ b/demo/src/main/res/layout/include_device_storage_root.xml
@@ -7,7 +7,7 @@
   tools:layout_editor_absoluteY="81dp">
 
   <TextView
-    android:id="@+id/device_storage_root"
+    android:id="@+id/device_storage_root_type"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginEnd="8dp"
@@ -19,7 +19,79 @@
     app:layout_constraintHorizontal_bias="0.5"
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toTopOf="parent"
+    tools:text="Type Item 01" />
+
+  <TextView
+    android:id="@+id/device_storage_root"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginEnd="8dp"
+    android:layout_marginLeft="8dp"
+    android:layout_marginRight="8dp"
+    android:layout_marginStart="8dp"
+    android:layout_marginTop="8dp"
+    app:layout_constraintTop_toBottomOf="@id/device_storage_root_type"
     tools:text="Item 01" />
+
+  <TextView
+    android:id="@+id/device_storage_root_used_size"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginEnd="8dp"
+    android:layout_marginLeft="8dp"
+    android:layout_marginRight="8dp"
+    android:layout_marginStart="8dp"
+    android:layout_marginTop="8dp"
+    app:layout_constraintTop_toBottomOf="@id/device_storage_root"
+    tools:text="Used Size Item 01" />
+
+  <TextView
+    android:id="@+id/device_storage_root_available_size"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginEnd="8dp"
+    android:layout_marginLeft="8dp"
+    android:layout_marginRight="8dp"
+    android:layout_marginStart="8dp"
+    android:layout_marginTop="8dp"
+    app:layout_constraintTop_toBottomOf="@id/device_storage_root_used_size"
+    tools:text="Available Size Item 01" />
+
+  <TextView
+    android:id="@+id/device_storage_root_total_size"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginEnd="8dp"
+    android:layout_marginLeft="8dp"
+    android:layout_marginRight="8dp"
+    android:layout_marginStart="8dp"
+    android:layout_marginTop="8dp"
+    app:layout_constraintTop_toBottomOf="@id/device_storage_root_available_size"
+    tools:text="Total Size Item 01" />
+
+  <TextView
+    android:id="@+id/device_storage_root_permissions"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginEnd="8dp"
+    android:layout_marginLeft="8dp"
+    android:layout_marginRight="8dp"
+    android:layout_marginStart="8dp"
+    android:layout_marginTop="8dp"
+    app:layout_constraintTop_toBottomOf="@id/device_storage_root_total_size"
+    tools:text="Permissions Item 01" />
+
+  <TextView
+    android:id="@+id/device_storage_root_state"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginEnd="8dp"
+    android:layout_marginLeft="8dp"
+    android:layout_marginRight="8dp"
+    android:layout_marginStart="8dp"
+    android:layout_marginTop="8dp"
+    app:layout_constraintTop_toBottomOf="@id/device_storage_root_permissions"
+    tools:text="Permissions Item 01" />
 
   <Button
     android:id="@+id/add_file"


### PR DESCRIPTION
## Summary

This upgrades the demo to add the following stats:
- Storage used
- Storage Available
- Storage Total
- Read/Write permissions
- Mounted state 
- if its removable
- if its emulated

## Testing / Screenshots
Need to get a device for the secondary storage to get the screen shots and more testing.

| Primary Base / Application Paths | Secondary Base / Application Paths |
| --- | --- | 
| ![device-2018-07-02-105456](https://user-images.githubusercontent.com/2613297/42157936-e8df364e-7de6-11e8-9f83-5cdb54f40037.png) | ![device-2018-07-02-142816](https://user-images.githubusercontent.com/2613297/42166862-3b9076e2-7e04-11e8-97db-92ecebe95961.png) | 


## Notes

If there is something obvious to refactor out it would make sense, but this will be covered to Kotlin in the very near future, so minor refactors that we be obsolete by a conversion to Kotlin might not make sense.
Might still be worthwhile commenting them though 🤷‍♂️ 


## Known Issues
For some API levels there are restrictions that mean we can't get certain pieces of data. 

#### storage size collection issues
API 18 is required for block size calculations, this is used for getting the used/available/total storage.
We can do this for `Primary` storage on all supported API levels via another method (the Environment calls), b this is only `Primary`.  For Secondary, we need to the StatFS functions with a path parameter, and this is only available for API 18 +.

#### Storage state collection issues
For the Storage states such as mount, removable and emulated, API 21 is required to collect them for Secondary storage. 
The states are collected via the `Environment.get...(` calls, and these are available for all supported API levels for the Primary path, but the version of these calls that allows you to pass a Path as a parameter was only introduced in API 21. And this is the way we need for getting the states for secondary storage.


