### PR TITLE
AndroidDeviceStorageInspector builder

### DIFF
--- a/demo/src/main/java/com/novoda/storagepathfinder/demo/DemoDependenciesFactory.java
+++ b/demo/src/main/java/com/novoda/storagepathfinder/demo/DemoDependenciesFactory.java
@@ -3,8 +3,6 @@ package com.novoda.storagepathfinder.demo;
 import android.content.Context;
 import android.content.res.AssetManager;
 
-import com.novoda.storagepathfinder.AndroidDeviceStorageInspector;
-
 import java.util.concurrent.Executors;
 
 public final class DemoDependenciesFactory {
@@ -16,9 +14,5 @@ public final class DemoDependenciesFactory {
     public static AssetCloner createAssetCloner(Context context) {
         AssetManager assetManager = context.getAssets();
         return new AssetCloner(assetManager, Executors.newSingleThreadExecutor());
-    }
-
-    public static AndroidDeviceStorageInspector createStorageInspector(Context context) {
-        return AndroidDeviceStorageInspector.builder(context).build();
     }
 }

--- a/demo/src/main/java/com/novoda/storagepathfinder/demo/DemoDependenciesFactory.java
+++ b/demo/src/main/java/com/novoda/storagepathfinder/demo/DemoDependenciesFactory.java
@@ -3,14 +3,7 @@ package com.novoda.storagepathfinder.demo;
 import android.content.Context;
 import android.content.res.AssetManager;
 
-import com.novoda.storagepathfinder.AndroidDeviceFeatures;
 import com.novoda.storagepathfinder.AndroidDeviceStorageInspector;
-import com.novoda.storagepathfinder.AndroidExternalStorageDirectories;
-import com.novoda.storagepathfinder.AndroidFileSystem;
-import com.novoda.storagepathfinder.AndroidSystem;
-import com.novoda.storagepathfinder.DeviceFeatures;
-import com.novoda.storagepathfinder.ExternalStorageDirectories;
-import com.novoda.storagepathfinder.FileSystem;
 
 import java.util.concurrent.Executors;
 
@@ -26,15 +19,6 @@ public final class DemoDependenciesFactory {
     }
 
     public static AndroidDeviceStorageInspector createStorageInspector(Context context) {
-        ExternalStorageDirectories externalStorageDirectories = new AndroidExternalStorageDirectories(context.getApplicationContext());
-        FileSystem fileSystem = new AndroidFileSystem(externalStorageDirectories);
-        DeviceFeatures deviceFeatures = new AndroidDeviceFeatures();
-        AndroidSystem androidSystem = new AndroidSystem();
-        return new AndroidDeviceStorageInspector(
-                context.getApplicationContext(),
-                fileSystem,
-                deviceFeatures,
-                androidSystem
-        );
+        return AndroidDeviceStorageInspector.builder(context).build();
     }
 }

--- a/demo/src/main/java/com/novoda/storagepathfinder/demo/LandingActivity.java
+++ b/demo/src/main/java/com/novoda/storagepathfinder/demo/LandingActivity.java
@@ -24,7 +24,7 @@ public class LandingActivity extends AppCompatActivity {
 
         assetCloner = DemoDependenciesFactory.createAssetCloner(getApplicationContext());
 
-        AndroidDeviceStorageInspector storageInspector = DemoDependenciesFactory.createStorageInspector(getApplicationContext());
+        AndroidDeviceStorageInspector storageInspector = AndroidDeviceStorageInspector.builder(this).build();
 
         List<StoragePath> deviceStoragePaths = new ArrayList<>();
 

--- a/demo/src/main/java/com/novoda/storagepathfinder/demo/LandingActivity.java
+++ b/demo/src/main/java/com/novoda/storagepathfinder/demo/LandingActivity.java
@@ -5,7 +5,7 @@ import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 
-import com.novoda.storagepathfinder.AndroidDeviceStorageInspector;
+import com.novoda.storagepathfinder.DeviceStorageInspector;
 import com.novoda.storagepathfinder.StoragePath;
 
 import java.util.ArrayList;
@@ -24,7 +24,7 @@ public class LandingActivity extends AppCompatActivity {
 
         assetCloner = DemoDependenciesFactory.createAssetCloner(getApplicationContext());
 
-        AndroidDeviceStorageInspector storageInspector = AndroidDeviceStorageInspector.builder(this).build();
+        DeviceStorageInspector storageInspector = DeviceStorageInspector.builder(this).build();
 
         List<StoragePath> deviceStoragePaths = new ArrayList<>();
 

--- a/library/src/main/java/com/novoda/storagepathfinder/AndroidDeviceStorageInspector.java
+++ b/library/src/main/java/com/novoda/storagepathfinder/AndroidDeviceStorageInspector.java
@@ -128,7 +128,7 @@ public class AndroidDeviceStorageInspector implements DeviceStorageInspector {
             );
         }
 
-        Builder(Context context, FileSystem fileSystem, DeviceFeatures deviceFeatures, AndroidSystem androidSystem) {
+        private Builder(Context context, FileSystem fileSystem, DeviceFeatures deviceFeatures, AndroidSystem androidSystem) {
             this.context = context;
             this.fileSystem = fileSystem;
             this.deviceFeatures = deviceFeatures;

--- a/library/src/main/java/com/novoda/storagepathfinder/AndroidDeviceStorageInspector.java
+++ b/library/src/main/java/com/novoda/storagepathfinder/AndroidDeviceStorageInspector.java
@@ -107,9 +107,9 @@ public class AndroidDeviceStorageInspector implements DeviceStorageInspector {
         return Builder.newInstance(context);
     }
 
-    public static class Builder {
+    public static final class Builder {
 
-        private Context context;
+        private final Context context;
         private FileSystem fileSystem;
         private DeviceFeatures deviceFeatures;
         private AndroidSystem androidSystem;

--- a/library/src/main/java/com/novoda/storagepathfinder/AndroidDeviceStorageInspector.java
+++ b/library/src/main/java/com/novoda/storagepathfinder/AndroidDeviceStorageInspector.java
@@ -10,23 +10,17 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
-/**
- * The inspector that can give all storage roots. both Primary and Secondary. (Internal External and External External)
- * Lots of sanitisation has to go on in these for null checks / empty lists etc.
- * <p>
- * Not it uses a set of secondary storage inspectors to find it in anyway it can.
- */
-public class AndroidDeviceStorageInspector implements DeviceStorageInspector {
+class AndroidDeviceStorageInspector implements DeviceStorageInspector {
 
     private final PrimaryDeviceStorageInspector primaryStorageInspector;
     private final List<SecondaryDeviceStorageInspector> secondaryStorageInspectors = new ArrayList<>();
     private final FileSystem fileSystem;
 
-    public AndroidDeviceStorageInspector(
-        Context context,
-        FileSystem fileSystem,
-        DeviceFeatures deviceFeatures,
-        AndroidSystem androidSystem
+    AndroidDeviceStorageInspector(
+            Context context,
+            FileSystem fileSystem,
+            DeviceFeatures deviceFeatures,
+            AndroidSystem androidSystem
     ) {
         this.fileSystem = fileSystem;
         ExternalStorageDirectories externalStorageDirectories = fileSystem.getCommonDirectories();
@@ -101,62 +95,5 @@ public class AndroidDeviceStorageInspector implements DeviceStorageInspector {
             }
             return lhs.hashCode() - rhs.hashCode();
         };
-    }
-
-    public static Builder builder(Context context) {
-        return Builder.newInstance(context);
-    }
-
-    public static final class Builder {
-
-        private final Context context;
-        private FileSystem fileSystem;
-        private DeviceFeatures deviceFeatures;
-        private AndroidSystem androidSystem;
-
-        private static Builder newInstance(Context context) {
-            Context applicationContext = context.getApplicationContext();
-            ExternalStorageDirectories externalStorageDirectories = new AndroidExternalStorageDirectories(applicationContext);
-            FileSystem fileSystem = new AndroidFileSystem(externalStorageDirectories);
-            DeviceFeatures deviceFeatures = new AndroidDeviceFeatures();
-            AndroidSystem androidSystem = new AndroidSystem();
-            return new Builder(
-                applicationContext,
-                fileSystem,
-                deviceFeatures,
-                androidSystem
-            );
-        }
-
-        private Builder(Context context, FileSystem fileSystem, DeviceFeatures deviceFeatures, AndroidSystem androidSystem) {
-            this.context = context;
-            this.fileSystem = fileSystem;
-            this.deviceFeatures = deviceFeatures;
-            this.androidSystem = androidSystem;
-        }
-
-        public Builder withFileSystem(FileSystem fileSystem) {
-            this.fileSystem = fileSystem;
-            return this;
-        }
-
-        public Builder withDeviceFeatures(DeviceFeatures deviceFeatures) {
-            this.deviceFeatures = deviceFeatures;
-            return this;
-        }
-
-        public Builder withAndroidSystem(AndroidSystem androidSystem) {
-            this.androidSystem = androidSystem;
-            return this;
-        }
-
-        public AndroidDeviceStorageInspector build() {
-            return new AndroidDeviceStorageInspector(
-                context,
-                fileSystem,
-                deviceFeatures,
-                androidSystem
-            );
-        }
     }
 }

--- a/library/src/main/java/com/novoda/storagepathfinder/AndroidDeviceStorageInspector.java
+++ b/library/src/main/java/com/novoda/storagepathfinder/AndroidDeviceStorageInspector.java
@@ -23,10 +23,10 @@ public class AndroidDeviceStorageInspector implements DeviceStorageInspector {
     private final FileSystem fileSystem;
 
     public AndroidDeviceStorageInspector(
-            Context context,
-            FileSystem fileSystem,
-            DeviceFeatures deviceFeatures,
-            AndroidSystem androidSystem
+        Context context,
+        FileSystem fileSystem,
+        DeviceFeatures deviceFeatures,
+        AndroidSystem androidSystem
     ) {
         this.fileSystem = fileSystem;
         ExternalStorageDirectories externalStorageDirectories = fileSystem.getCommonDirectories();
@@ -101,5 +101,62 @@ public class AndroidDeviceStorageInspector implements DeviceStorageInspector {
             }
             return lhs.hashCode() - rhs.hashCode();
         };
+    }
+
+    public static Builder builder(Context context) {
+        return Builder.newInstance(context);
+    }
+
+    public static class Builder {
+
+        private Context context;
+        private FileSystem fileSystem;
+        private DeviceFeatures deviceFeatures;
+        private AndroidSystem androidSystem;
+
+        private static Builder newInstance(Context context) {
+            Context applicationContext = context.getApplicationContext();
+            ExternalStorageDirectories externalStorageDirectories = new AndroidExternalStorageDirectories(applicationContext);
+            FileSystem fileSystem = new AndroidFileSystem(externalStorageDirectories);
+            DeviceFeatures deviceFeatures = new AndroidDeviceFeatures();
+            AndroidSystem androidSystem = new AndroidSystem();
+            return new Builder(
+                applicationContext,
+                fileSystem,
+                deviceFeatures,
+                androidSystem
+            );
+        }
+
+        Builder(Context context, FileSystem fileSystem, DeviceFeatures deviceFeatures, AndroidSystem androidSystem) {
+            this.context = context;
+            this.fileSystem = fileSystem;
+            this.deviceFeatures = deviceFeatures;
+            this.androidSystem = androidSystem;
+        }
+
+        public Builder withFileSystem(FileSystem fileSystem) {
+            this.fileSystem = fileSystem;
+            return this;
+        }
+
+        public Builder withDeviceFeatures(DeviceFeatures deviceFeatures) {
+            this.deviceFeatures = deviceFeatures;
+            return this;
+        }
+
+        public Builder withAndroidSystem(AndroidSystem androidSystem) {
+            this.androidSystem = androidSystem;
+            return this;
+        }
+
+        public AndroidDeviceStorageInspector build() {
+            return new AndroidDeviceStorageInspector(
+                context,
+                fileSystem,
+                deviceFeatures,
+                androidSystem
+            );
+        }
     }
 }

--- a/library/src/main/java/com/novoda/storagepathfinder/DeviceStorageInspector.java
+++ b/library/src/main/java/com/novoda/storagepathfinder/DeviceStorageInspector.java
@@ -36,61 +36,8 @@ public interface DeviceStorageInspector {
      */
     List<StoragePath> getSecondaryStorageApplicationPath();
 
-    static Builder builder(Context context) {
-        return Builder.newInstance(context);
-    }
-
-    final class Builder {
-
-        private final Context context;
-        private FileSystem fileSystem;
-        private DeviceFeatures deviceFeatures;
-        private AndroidSystem androidSystem;
-
-        private static Builder newInstance(Context context) {
-            Context applicationContext = context.getApplicationContext();
-            ExternalStorageDirectories externalStorageDirectories = new AndroidExternalStorageDirectories(applicationContext);
-            FileSystem fileSystem = new AndroidFileSystem(externalStorageDirectories);
-            DeviceFeatures deviceFeatures = new AndroidDeviceFeatures();
-            AndroidSystem androidSystem = new AndroidSystem();
-            return new Builder(
-                    applicationContext,
-                    fileSystem,
-                    deviceFeatures,
-                    androidSystem
-            );
-        }
-
-        private Builder(Context context, FileSystem fileSystem, DeviceFeatures deviceFeatures, AndroidSystem androidSystem) {
-            this.context = context;
-            this.fileSystem = fileSystem;
-            this.deviceFeatures = deviceFeatures;
-            this.androidSystem = androidSystem;
-        }
-
-        public Builder withFileSystem(FileSystem fileSystem) {
-            this.fileSystem = fileSystem;
-            return this;
-        }
-
-        public Builder withDeviceFeatures(DeviceFeatures deviceFeatures) {
-            this.deviceFeatures = deviceFeatures;
-            return this;
-        }
-
-        public Builder withAndroidSystem(AndroidSystem androidSystem) {
-            this.androidSystem = androidSystem;
-            return this;
-        }
-
-        public DeviceStorageInspector build() {
-            return new AndroidDeviceStorageInspector(
-                    context,
-                    fileSystem,
-                    deviceFeatures,
-                    androidSystem
-            );
-        }
+    static DeviceStorageInspectorBuilder builder(Context context) {
+        return DeviceStorageInspectorBuilder.newInstance(context);
     }
 
 }

--- a/library/src/main/java/com/novoda/storagepathfinder/DeviceStorageInspector.java
+++ b/library/src/main/java/com/novoda/storagepathfinder/DeviceStorageInspector.java
@@ -1,7 +1,15 @@
 package com.novoda.storagepathfinder;
 
+import android.content.Context;
+
 import java.util.List;
 
+/**
+ * The inspector that can give all storage roots, both Primary and Secondary. (Internal External and External External)
+ * Lots of sanitisation has to go on in these for null checks / empty lists etc.
+ * <p>
+ * Note: It uses a set of secondary storage inspectors to find it in anyway it can.
+ */
 public interface DeviceStorageInspector {
 
     /**
@@ -27,5 +35,62 @@ public interface DeviceStorageInspector {
      * (this is most likely your SD Card)
      */
     List<StoragePath> getSecondaryStorageApplicationPath();
+
+    static Builder builder(Context context) {
+        return Builder.newInstance(context);
+    }
+
+    final class Builder {
+
+        private final Context context;
+        private FileSystem fileSystem;
+        private DeviceFeatures deviceFeatures;
+        private AndroidSystem androidSystem;
+
+        private static Builder newInstance(Context context) {
+            Context applicationContext = context.getApplicationContext();
+            ExternalStorageDirectories externalStorageDirectories = new AndroidExternalStorageDirectories(applicationContext);
+            FileSystem fileSystem = new AndroidFileSystem(externalStorageDirectories);
+            DeviceFeatures deviceFeatures = new AndroidDeviceFeatures();
+            AndroidSystem androidSystem = new AndroidSystem();
+            return new Builder(
+                    applicationContext,
+                    fileSystem,
+                    deviceFeatures,
+                    androidSystem
+            );
+        }
+
+        private Builder(Context context, FileSystem fileSystem, DeviceFeatures deviceFeatures, AndroidSystem androidSystem) {
+            this.context = context;
+            this.fileSystem = fileSystem;
+            this.deviceFeatures = deviceFeatures;
+            this.androidSystem = androidSystem;
+        }
+
+        public Builder withFileSystem(FileSystem fileSystem) {
+            this.fileSystem = fileSystem;
+            return this;
+        }
+
+        public Builder withDeviceFeatures(DeviceFeatures deviceFeatures) {
+            this.deviceFeatures = deviceFeatures;
+            return this;
+        }
+
+        public Builder withAndroidSystem(AndroidSystem androidSystem) {
+            this.androidSystem = androidSystem;
+            return this;
+        }
+
+        public DeviceStorageInspector build() {
+            return new AndroidDeviceStorageInspector(
+                    context,
+                    fileSystem,
+                    deviceFeatures,
+                    androidSystem
+            );
+        }
+    }
 
 }

--- a/library/src/main/java/com/novoda/storagepathfinder/DeviceStorageInspectorBuilder.java
+++ b/library/src/main/java/com/novoda/storagepathfinder/DeviceStorageInspectorBuilder.java
@@ -1,0 +1,56 @@
+package com.novoda.storagepathfinder;
+
+import android.content.Context;
+
+public final class DeviceStorageInspectorBuilder {
+
+    private final Context context;
+    private FileSystem fileSystem;
+    private DeviceFeatures deviceFeatures;
+    private AndroidSystem androidSystem;
+
+    static DeviceStorageInspectorBuilder newInstance(Context context) {
+        Context applicationContext = context.getApplicationContext();
+        ExternalStorageDirectories externalStorageDirectories = new AndroidExternalStorageDirectories(applicationContext);
+        FileSystem fileSystem = new AndroidFileSystem(externalStorageDirectories);
+        DeviceFeatures deviceFeatures = new AndroidDeviceFeatures();
+        AndroidSystem androidSystem = new AndroidSystem();
+        return new DeviceStorageInspectorBuilder(
+                applicationContext,
+                fileSystem,
+                deviceFeatures,
+                androidSystem
+        );
+    }
+
+    private DeviceStorageInspectorBuilder(Context context, FileSystem fileSystem, DeviceFeatures deviceFeatures, AndroidSystem androidSystem) {
+        this.context = context;
+        this.fileSystem = fileSystem;
+        this.deviceFeatures = deviceFeatures;
+        this.androidSystem = androidSystem;
+    }
+
+    public DeviceStorageInspectorBuilder withFileSystem(FileSystem fileSystem) {
+        this.fileSystem = fileSystem;
+        return this;
+    }
+
+    public DeviceStorageInspectorBuilder withDeviceFeatures(DeviceFeatures deviceFeatures) {
+        this.deviceFeatures = deviceFeatures;
+        return this;
+    }
+
+    public DeviceStorageInspectorBuilder withAndroidSystem(AndroidSystem androidSystem) {
+        this.androidSystem = androidSystem;
+        return this;
+    }
+
+    public DeviceStorageInspector build() {
+        return new AndroidDeviceStorageInspector(
+                context,
+                fileSystem,
+                deviceFeatures,
+                androidSystem
+        );
+    }
+}


### PR DESCRIPTION
## Problem
The library required every client to manually create all the dependencies for `AndroidDeviceStorageInspector`, even if for most of the cases they were gonna be always the same

## Solution
Create a builder with the defaults we previously put in the demo app

### Paired with
@Mecharyry 