### PR TITLE
FileUtils crashing for `.android_secure`

### DIFF
--- a/demo/src/main/java/com/novoda/storagepathfinder/demo/FileSizeFinder.java
+++ b/demo/src/main/java/com/novoda/storagepathfinder/demo/FileSizeFinder.java
@@ -31,7 +31,7 @@ final class FileSizeFinder {
 
         long size = 0;
 
-        for (final File file : files) {
+        for (File file : files) {
             try {
                 if (!FileUtils.isSymlink(file)) {
                     size += sizeOf(file);

--- a/demo/src/main/java/com/novoda/storagepathfinder/demo/FileSizeFinder.java
+++ b/demo/src/main/java/com/novoda/storagepathfinder/demo/FileSizeFinder.java
@@ -1,0 +1,66 @@
+package com.novoda.storagepathfinder.demo;
+
+import android.support.annotation.NonNull;
+import android.util.Log;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.io.FileUtils;
+
+final class FileSizeFinder {
+
+    private FileSizeFinder() {
+        // Uses static factory methods.
+    }
+
+    /**
+     * Counts the size of a directory recursively (sum of the length of all files).
+     *
+     * @param directory directory to inspect, must not be {@code null}
+     * @return size of directory in bytes, 0 if directory is security restricted, a negative number when the real total
+     * is greater than {@link Long#MAX_VALUE}.
+     * @throws NullPointerException if the directory is {@code null}
+     */
+    static long sizeOfDirectory(File directory) {
+        File[] files = directory.listFiles();
+
+        if (files == null) {
+            return 0L;
+        }
+
+        long size = 0;
+
+        for (final File file : files) {
+            try {
+                if (!FileUtils.isSymlink(file)) {
+                    size += sizeOf(file);
+                }
+            } catch (IOException exception) {
+                Log.e(FileSizeFinder.class.getSimpleName(), "Ignoring exceptions caught from symlink.", exception);
+            }
+        }
+        return size;
+    }
+
+    /**
+     * Returns the size of the specified file or directory. If the provided
+     * {@link File} is a regular file, then the file's length is returned.
+     * If the argument is a directory, then the size of the directory is
+     * calculated recursively. If a directory or subdirectory is security
+     * restricted, its size will not be included.
+     *
+     * @param file the regular file or directory to return the size
+     *             of (must not be {@code null}).
+     * @return the length of the file, or recursive size of the directory,
+     * provided (in bytes).
+     * @throws NullPointerException if the file is {@code null}
+     */
+    private static long sizeOf(@NonNull File file) {
+        if (file.isDirectory()) {
+            return sizeOfDirectory(file);
+        } else {
+            return file.length();
+        }
+    }
+}

--- a/demo/src/main/java/com/novoda/storagepathfinder/demo/FileSizeFinder.java
+++ b/demo/src/main/java/com/novoda/storagepathfinder/demo/FileSizeFinder.java
@@ -11,7 +11,7 @@ import org.apache.commons.io.FileUtils;
 final class FileSizeFinder {
 
     private FileSizeFinder() {
-        // Uses static factory methods.
+        // Uses static utility methods.
     }
 
     /**

--- a/demo/src/main/java/com/novoda/storagepathfinder/demo/FileSizeFinder.java
+++ b/demo/src/main/java/com/novoda/storagepathfinder/demo/FileSizeFinder.java
@@ -15,7 +15,7 @@ final class FileSizeFinder {
     }
 
     /**
-     * Counts the size of a directory recursively (sum of the length of all files).
+     * Calculates the size of a directory recursively (sum of the length of all files).
      *
      * @param directory directory to inspect, must not be {@code null}
      * @return size of directory in bytes, 0 if directory is security restricted, a negative number when the real total

--- a/demo/src/main/java/com/novoda/storagepathfinder/demo/StoragePathViewHolder.java
+++ b/demo/src/main/java/com/novoda/storagepathfinder/demo/StoragePathViewHolder.java
@@ -12,8 +12,6 @@ import com.novoda.storagepathfinder.StoragePath;
 
 import java.io.File;
 
-import org.apache.commons.io.FileUtils;
-
 import static android.os.Build.VERSION.SDK_INT;
 import static com.novoda.storagepathfinder.StoragePath.Type.PRIMARY;
 import static com.novoda.storagepathfinder.StoragePath.Type.SECONDARY;
@@ -96,7 +94,7 @@ class StoragePathViewHolder extends RecyclerView.ViewHolder {
 
     private String getSizeOf(StoragePath deviceStoragePath) {
         File pathAsFile = deviceStoragePath.getPathAsFile();
-        long sizeOfDirectory = FileUtils.sizeOfDirectory(pathAsFile);
+        long sizeOfDirectory = FileSizeFinder.sizeOfDirectory(pathAsFile);
         if (sizeOfDirectory == 0 && deviceStoragePath.getType() == PRIMARY) {
             sizeOfDirectory = getSizeFromBlockCalculations(deviceStoragePath);
         }


### PR DESCRIPTION
## Problem 
In #6 the demo application crashes on `Asus Zenfone II` with an SD card because the `.android_secure` is retrieved and then flagged as not existing.

## Solution
Roll our own version of `FileUtils.sizeOfDirectory` where rather than explicitly crashing when a file does not exist allow the `File.length` to be trigged. The `File.length` checks for a valid file, if the file is invalid then it will return `0` as the size, which is great 👍  