### PR TITLE
API 16 Shared Storage Crash

### DIFF
--- a/demo/src/main/java/com/novoda/storagepathfinder/demo/LandingActivity.java
+++ b/demo/src/main/java/com/novoda/storagepathfinder/demo/LandingActivity.java
@@ -28,8 +28,8 @@ public class LandingActivity extends AppCompatActivity {
 
         List<StoragePath> deviceStoragePaths = new ArrayList<>();
 
-        deviceStoragePaths.add(storageInspector.getPrimaryStorageBasePath());
-        deviceStoragePaths.add(storageInspector.getPrimaryStorageApplicationPath());
+        deviceStoragePaths.addAll(storageInspector.getPrimaryStorageBasePath());
+        deviceStoragePaths.addAll(storageInspector.getPrimaryStorageApplicationPath());
         deviceStoragePaths.addAll(storageInspector.getSecondaryStorageBasePath());
         deviceStoragePaths.addAll(storageInspector.getSecondaryStorageApplicationPath());
 

--- a/demo/src/main/java/com/novoda/storagepathfinder/demo/LandingActivity.java
+++ b/demo/src/main/java/com/novoda/storagepathfinder/demo/LandingActivity.java
@@ -28,10 +28,10 @@ public class LandingActivity extends AppCompatActivity {
 
         List<StoragePath> deviceStoragePaths = new ArrayList<>();
 
-        deviceStoragePaths.addAll(storageInspector.getPrimaryStorageBasePath());
-        deviceStoragePaths.addAll(storageInspector.getPrimaryStorageApplicationPath());
-        deviceStoragePaths.addAll(storageInspector.getSecondaryStorageBasePath());
-        deviceStoragePaths.addAll(storageInspector.getSecondaryStorageApplicationPath());
+        deviceStoragePaths.addAll(storageInspector.getPrimaryStorageBasePaths());
+        deviceStoragePaths.addAll(storageInspector.getPrimaryStorageApplicationPaths());
+        deviceStoragePaths.addAll(storageInspector.getSecondaryStorageBasePaths());
+        deviceStoragePaths.addAll(storageInspector.getSecondaryStorageApplicationPaths());
 
         RecyclerView recyclerView = findViewById(R.id.device_storage_roots);
         recyclerView.setLayoutManager(new LinearLayoutManager(getApplicationContext()));

--- a/library/src/main/java/com/novoda/storagepathfinder/AndroidDeviceStorageInspector.java
+++ b/library/src/main/java/com/novoda/storagepathfinder/AndroidDeviceStorageInspector.java
@@ -26,19 +26,19 @@ class AndroidDeviceStorageInspector implements DeviceStorageInspector {
         ExternalStorageDirectories externalStorageDirectories = fileSystem.getCommonDirectories();
         primaryStorageInspector = new ExternalDirectoryPrimaryStorageInspector(externalStorageDirectories);
 
-        StoragePath primaryBasePath = primaryStorageInspector.getPrimaryDeviceStorageBasePath();
+        List<StoragePath> primaryBasePaths = primaryStorageInspector.getPrimaryDeviceStorageBasePath();
         secondaryStorageInspectors.add(new EnvironmentVariableStorageInspector(androidSystem));
-        secondaryStorageInspectors.add(new ExternalFileDirectoryInspector(context, deviceFeatures, primaryBasePath.getPathAsString()));
+        secondaryStorageInspectors.add(new ExternalFileDirectoryInspector(context, deviceFeatures, primaryBasePaths));
     }
 
     @Override
-    public StoragePath getPrimaryStorageBasePath() {
+    public List<StoragePath> getPrimaryStorageBasePath() {
         return primaryStorageInspector.getPrimaryDeviceStorageBasePath();
 
     }
 
     @Override
-    public StoragePath getPrimaryStorageApplicationPath() {
+    public List<StoragePath> getPrimaryStorageApplicationPath() {
         return primaryStorageInspector.getPrimaryDeviceStorageApplicationPath();
     }
 

--- a/library/src/main/java/com/novoda/storagepathfinder/AndroidDeviceStorageInspector.java
+++ b/library/src/main/java/com/novoda/storagepathfinder/AndroidDeviceStorageInspector.java
@@ -32,24 +32,24 @@ class AndroidDeviceStorageInspector implements DeviceStorageInspector {
     }
 
     @Override
-    public List<StoragePath> getPrimaryStorageBasePath() {
+    public List<StoragePath> getPrimaryStorageBasePaths() {
         return primaryStorageInspector.getPrimaryDeviceStorageBasePath();
 
     }
 
     @Override
-    public List<StoragePath> getPrimaryStorageApplicationPath() {
+    public List<StoragePath> getPrimaryStorageApplicationPaths() {
         return primaryStorageInspector.getPrimaryDeviceStorageApplicationPath();
     }
 
     @Override
-    public List<StoragePath> getSecondaryStorageBasePath() {
+    public List<StoragePath> getSecondaryStorageBasePaths() {
         List<StoragePath> storageRoots = new ArrayList<>(findActiveSecondaryStorageBasePaths());
         return Collections.unmodifiableList(storageRoots);
     }
 
     @Override
-    public List<StoragePath> getSecondaryStorageApplicationPath() {
+    public List<StoragePath> getSecondaryStorageApplicationPaths() {
         List<StoragePath> storageRoots = new ArrayList<>(findActiveSecondaryStorageApplicationPaths());
         return Collections.unmodifiableList(storageRoots);
     }

--- a/library/src/main/java/com/novoda/storagepathfinder/AndroidExternalStorageDirectories.java
+++ b/library/src/main/java/com/novoda/storagepathfinder/AndroidExternalStorageDirectories.java
@@ -2,6 +2,7 @@ package com.novoda.storagepathfinder;
 
 import android.content.Context;
 import android.os.Environment;
+import android.support.annotation.Nullable;
 import android.support.v4.content.ContextCompat;
 
 import java.io.File;
@@ -20,6 +21,7 @@ public class AndroidExternalStorageDirectories implements ExternalStorageDirecto
         this.context = context;
     }
 
+    @Nullable
     @Override
     public File getExternalStorageDirectoryApplicationPath() {
         return ContextCompat.getExternalFilesDirs(context, null)[0];

--- a/library/src/main/java/com/novoda/storagepathfinder/DeviceStorageInspector.java
+++ b/library/src/main/java/com/novoda/storagepathfinder/DeviceStorageInspector.java
@@ -16,25 +16,25 @@ public interface DeviceStorageInspector {
      * The system storage path of your primary storage.
      * (this is most likely built in phone storage)
      */
-    List<StoragePath> getPrimaryStorageBasePath();
+    List<StoragePath> getPrimaryStorageBasePaths();
 
     /**
      * The system storage path of your secondary storage.
      * (this is most likely your SD Card)
      */
-    List<StoragePath> getSecondaryStorageBasePath();
+    List<StoragePath> getSecondaryStorageBasePaths();
 
     /**
      * The application storage path of your primary storage.
      * (this is most likely built in phone storage)
      */
-    List<StoragePath> getPrimaryStorageApplicationPath();
+    List<StoragePath> getPrimaryStorageApplicationPaths();
 
     /**
      * The application storage path of your secondary storage.
      * (this is most likely your SD Card)
      */
-    List<StoragePath> getSecondaryStorageApplicationPath();
+    List<StoragePath> getSecondaryStorageApplicationPaths();
 
     static DeviceStorageInspectorBuilder builder(Context context) {
         return DeviceStorageInspectorBuilder.newInstance(context);

--- a/library/src/main/java/com/novoda/storagepathfinder/DeviceStorageInspector.java
+++ b/library/src/main/java/com/novoda/storagepathfinder/DeviceStorageInspector.java
@@ -16,7 +16,7 @@ public interface DeviceStorageInspector {
      * The system storage path of your primary storage.
      * (this is most likely built in phone storage)
      */
-    StoragePath getPrimaryStorageBasePath();
+    List<StoragePath> getPrimaryStorageBasePath();
 
     /**
      * The system storage path of your secondary storage.
@@ -28,7 +28,7 @@ public interface DeviceStorageInspector {
      * The application storage path of your primary storage.
      * (this is most likely built in phone storage)
      */
-    StoragePath getPrimaryStorageApplicationPath();
+    List<StoragePath> getPrimaryStorageApplicationPath();
 
     /**
      * The application storage path of your secondary storage.

--- a/library/src/main/java/com/novoda/storagepathfinder/ExternalDirectoryPrimaryStorageInspector.java
+++ b/library/src/main/java/com/novoda/storagepathfinder/ExternalDirectoryPrimaryStorageInspector.java
@@ -1,12 +1,16 @@
 package com.novoda.storagepathfinder;
 
+import android.util.Log;
+
 import java.io.File;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
 class ExternalDirectoryPrimaryStorageInspector implements PrimaryDeviceStorageInspector {
 
     private static final StoragePath.Type PRIMARY = StoragePath.Type.PRIMARY;
+    private static final String EMPTY_PATH = "";
     private final ExternalStorageDirectories externalStorageDirectories;
 
     ExternalDirectoryPrimaryStorageInspector(ExternalStorageDirectories externalStorageDirectories) {
@@ -16,7 +20,7 @@ class ExternalDirectoryPrimaryStorageInspector implements PrimaryDeviceStorageIn
     @Override
     public List<StoragePath> getPrimaryDeviceStorageBasePath() {
         File externalStorageDirectoryBasePath = externalStorageDirectories.getExternalStorageDirectoryBasePath();
-        if (externalStorageDirectoryBasePath == null) {
+        if (externalStorageDirectoryBasePath == null || canonicalOrEmpty(externalStorageDirectoryBasePath).isEmpty()) {
             return Collections.emptyList();
         }
 
@@ -27,11 +31,20 @@ class ExternalDirectoryPrimaryStorageInspector implements PrimaryDeviceStorageIn
     @Override
     public List<StoragePath> getPrimaryDeviceStorageApplicationPath() {
         File externalStorageDirectoryApplicationPath = externalStorageDirectories.getExternalStorageDirectoryApplicationPath();
-        if (externalStorageDirectoryApplicationPath == null) {
+        if (externalStorageDirectoryApplicationPath == null || canonicalOrEmpty(externalStorageDirectoryApplicationPath).isEmpty()) {
             return Collections.emptyList();
         }
 
         StoragePath storagePath = DeviceStoragePath.create(externalStorageDirectoryApplicationPath.getPath(), PRIMARY);
         return Collections.singletonList(storagePath);
+    }
+
+    private String canonicalOrEmpty(File file) {
+        try {
+            return file.getCanonicalPath();
+        } catch (IOException e) {
+            Log.e(getClass().getSimpleName(), "Could not retrieve canonical path.", e);
+        }
+        return EMPTY_PATH;
     }
 }

--- a/library/src/main/java/com/novoda/storagepathfinder/ExternalDirectoryPrimaryStorageInspector.java
+++ b/library/src/main/java/com/novoda/storagepathfinder/ExternalDirectoryPrimaryStorageInspector.java
@@ -1,5 +1,9 @@
 package com.novoda.storagepathfinder;
 
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+
 class ExternalDirectoryPrimaryStorageInspector implements PrimaryDeviceStorageInspector {
 
     private static final StoragePath.Type PRIMARY = StoragePath.Type.PRIMARY;
@@ -10,14 +14,24 @@ class ExternalDirectoryPrimaryStorageInspector implements PrimaryDeviceStorageIn
     }
 
     @Override
-    public StoragePath getPrimaryDeviceStorageBasePath() {
-        String path = externalStorageDirectories.getExternalStorageDirectoryBasePath().getPath();
-        return DeviceStoragePath.create(path, PRIMARY);
+    public List<StoragePath> getPrimaryDeviceStorageBasePath() {
+        File externalStorageDirectoryBasePath = externalStorageDirectories.getExternalStorageDirectoryBasePath();
+        if (externalStorageDirectoryBasePath == null) {
+            return Collections.emptyList();
+        }
+
+        StoragePath storagePath = DeviceStoragePath.create(externalStorageDirectoryBasePath.getPath(), PRIMARY);
+        return Collections.singletonList(storagePath);
     }
 
     @Override
-    public StoragePath getPrimaryDeviceStorageApplicationPath() {
-        String path = externalStorageDirectories.getExternalStorageDirectoryApplicationPath().getPath();
-        return DeviceStoragePath.create(path, PRIMARY);
+    public List<StoragePath> getPrimaryDeviceStorageApplicationPath() {
+        File externalStorageDirectoryApplicationPath = externalStorageDirectories.getExternalStorageDirectoryApplicationPath();
+        if (externalStorageDirectoryApplicationPath == null) {
+            return Collections.emptyList();
+        }
+
+        StoragePath storagePath = DeviceStoragePath.create(externalStorageDirectoryApplicationPath.getPath(), PRIMARY);
+        return Collections.singletonList(storagePath);
     }
 }

--- a/library/src/main/java/com/novoda/storagepathfinder/ExternalFileDirectoryInspector.java
+++ b/library/src/main/java/com/novoda/storagepathfinder/ExternalFileDirectoryInspector.java
@@ -47,9 +47,7 @@ public class ExternalFileDirectoryInspector implements SecondaryDeviceStorageIns
     @TargetApi(Build.VERSION_CODES.KITKAT)
     private List<StoragePath> checkExternalFileDirectoriesForRemovableStorage(Filter base) {
         File[] externalFileDirectories = filterOutNullValuesFrom(context.getExternalFilesDirs(null));
-        List<StoragePath> storageRoots = new ArrayList<>();
-        storageRoots.addAll(extractSecondaryStorageRootsFrom(base, externalFileDirectories));
-        return storageRoots;
+        return new ArrayList<>(extractSecondaryStorageRootsFrom(base, externalFileDirectories));
     }
 
     private File[] filterOutNullValuesFrom(File... externalFilesDirs) {  // YES They return a list with null values in it...

--- a/library/src/main/java/com/novoda/storagepathfinder/ExternalFileDirectoryInspector.java
+++ b/library/src/main/java/com/novoda/storagepathfinder/ExternalFileDirectoryInspector.java
@@ -24,12 +24,12 @@ public class ExternalFileDirectoryInspector implements SecondaryDeviceStorageIns
 
     private final Context context;
     private final DeviceFeatures deviceFeatures;
-    private final String primaryStoragePath;
+    private final List<StoragePath> primaryStoragePaths;
 
-    ExternalFileDirectoryInspector(Context context, DeviceFeatures deviceFeatures, String primaryStoragePath) {
+    ExternalFileDirectoryInspector(Context context, DeviceFeatures deviceFeatures, List<StoragePath> primaryStoragePaths) {
         this.context = context;
         this.deviceFeatures = deviceFeatures;
-        this.primaryStoragePath = primaryStoragePath;
+        this.primaryStoragePaths = primaryStoragePaths;
     }
 
     @Override
@@ -93,6 +93,15 @@ public class ExternalFileDirectoryInspector implements SecondaryDeviceStorageIns
         if (base == Filter.APPLICATION) {
             pathToCompare = getDirectoryPathAboveTheAndroidFolderFrom(new File(absolutePath));
         }
-        return !pathToCompare.isEmpty() && !pathToCompare.equals(primaryStoragePath);
+        return !pathToCompare.isEmpty() && !isSameAsPrimaryStoragePath(pathToCompare);
+    }
+
+    private boolean isSameAsPrimaryStoragePath(String pathToCompare) {
+        for (StoragePath primaryStoragePath : primaryStoragePaths) {
+            if (pathToCompare.equals(primaryStoragePath.getPathAsString())) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/library/src/main/java/com/novoda/storagepathfinder/ExternalFileDirectoryInspector.java
+++ b/library/src/main/java/com/novoda/storagepathfinder/ExternalFileDirectoryInspector.java
@@ -3,8 +3,10 @@ package com.novoda.storagepathfinder;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.os.Build;
+import android.util.Log;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -16,6 +18,7 @@ public class ExternalFileDirectoryInspector implements SecondaryDeviceStorageIns
 
     private static final StoragePath.Type SECONDARY = StoragePath.Type.SECONDARY;
     private static final String ANDROID_PATTERN = "/(Android)";
+    private static final String EMPTY_PATH = "";
 
     public enum Filter {   // TODO kill this soon
         APPLICATION,
@@ -67,13 +70,8 @@ public class ExternalFileDirectoryInspector implements SecondaryDeviceStorageIns
         List<StoragePath> storageRoots = new ArrayList<>();
         for (File file : fileDirectories) {
             // TODO I don't want this Filter.TYPE thing, but its the fastest way to split the logic for now. More refactoring later
-            String path = "";
-            if (base.equals(Filter.BASE)) {
-                path = getDirectoryPathAboveTheAndroidFolderFrom(file);
-            }
-            if (base.equals(Filter.APPLICATION)) {
-                path = file.getAbsolutePath();
-            }
+            String path = pathFromFilter(base, file);
+
             if (isValidPathForSecondaryStorage(path, base)) {
                 storageRoots.add(DeviceStoragePath.create(path, SECONDARY));
             }
@@ -81,9 +79,33 @@ public class ExternalFileDirectoryInspector implements SecondaryDeviceStorageIns
         return storageRoots;
     }
 
+    private String pathFromFilter(Filter base, File file) {
+        if (base.equals(Filter.BASE)) {
+            return getDirectoryPathAboveTheAndroidFolderFrom(file);
+        }
+        if (base.equals(Filter.APPLICATION)) {
+            return getApplicationPath(file);
+        }
+        return EMPTY_PATH;
+    }
+
     private String getDirectoryPathAboveTheAndroidFolderFrom(File file) {
-        String path = file.getAbsolutePath().split(ANDROID_PATTERN)[0];
+        String path = null;
+        try {
+            path = file.getCanonicalPath().split(ANDROID_PATTERN)[0];
+        } catch (IOException e) {
+            Log.e(getClass().getSimpleName(), "Could not find directory path above android folder", e);
+        }
         return path == null ? "" : path;
+    }
+
+    private String getApplicationPath(File file) {
+        try {
+            return file.getCanonicalPath();
+        } catch (IOException e) {
+            Log.e(getClass().getSimpleName(), "Could not find application path.", e);
+        }
+        return EMPTY_PATH;
     }
 
     private boolean isValidPathForSecondaryStorage(String absolutePath, Filter base) {

--- a/library/src/main/java/com/novoda/storagepathfinder/PrimaryDeviceStorageInspector.java
+++ b/library/src/main/java/com/novoda/storagepathfinder/PrimaryDeviceStorageInspector.java
@@ -1,8 +1,10 @@
 package com.novoda.storagepathfinder;
 
+import java.util.List;
+
 interface PrimaryDeviceStorageInspector {
 
-    StoragePath getPrimaryDeviceStorageBasePath();
+    List<StoragePath> getPrimaryDeviceStorageBasePath();
 
-    StoragePath getPrimaryDeviceStorageApplicationPath();
+    List<StoragePath> getPrimaryDeviceStorageApplicationPath();
 }

--- a/library/src/test/java/com/novoda/storagepathfinder/AndroidDeviceStorageInspectorTest.java
+++ b/library/src/test/java/com/novoda/storagepathfinder/AndroidDeviceStorageInspectorTest.java
@@ -54,16 +54,18 @@ public class AndroidDeviceStorageInspectorTest {
 
     @Test
     public void returnsThePrimaryStorageBasePath() {
-        StoragePath basePath = storageInspector.getPrimaryStorageBasePath();
+        List<StoragePath> storagePaths = storageInspector.getPrimaryStorageBasePath();
 
-        assertThat(basePath).isEqualTo(PRIMARY_BASE_PATH);
+        assertThat(storagePaths.size()) .isEqualTo(1);
+        assertThat(storagePaths.get(0)).isEqualTo(PRIMARY_BASE_PATH);
     }
 
     @Test
     public void returnsThePrimaryStorageApplicationPath() {
-        StoragePath basePath = storageInspector.getPrimaryStorageApplicationPath();
+        List<StoragePath> storagePaths = storageInspector.getPrimaryStorageApplicationPath();
 
-        assertThat(basePath).isEqualTo(PRIMARY_APPLICATION_PATH);
+        assertThat(storagePaths.size()).isEqualTo(1);
+        assertThat(storagePaths.get(0)).isEqualTo(PRIMARY_APPLICATION_PATH);
     }
 
     @Test

--- a/library/src/test/java/com/novoda/storagepathfinder/AndroidDeviceStorageInspectorTest.java
+++ b/library/src/test/java/com/novoda/storagepathfinder/AndroidDeviceStorageInspectorTest.java
@@ -56,7 +56,7 @@ public class AndroidDeviceStorageInspectorTest {
     public void returnsThePrimaryStorageBasePath() {
         List<StoragePath> storagePaths = storageInspector.getPrimaryStorageBasePaths();
 
-        assertThat(storagePaths.size()) .isEqualTo(1);
+        assertThat(storagePaths.size()).isEqualTo(1);
         assertThat(storagePaths.get(0)).isEqualTo(PRIMARY_BASE_PATH);
     }
 

--- a/library/src/test/java/com/novoda/storagepathfinder/AndroidDeviceStorageInspectorTest.java
+++ b/library/src/test/java/com/novoda/storagepathfinder/AndroidDeviceStorageInspectorTest.java
@@ -54,7 +54,7 @@ public class AndroidDeviceStorageInspectorTest {
 
     @Test
     public void returnsThePrimaryStorageBasePath() {
-        List<StoragePath> storagePaths = storageInspector.getPrimaryStorageBasePath();
+        List<StoragePath> storagePaths = storageInspector.getPrimaryStorageBasePaths();
 
         assertThat(storagePaths.size()) .isEqualTo(1);
         assertThat(storagePaths.get(0)).isEqualTo(PRIMARY_BASE_PATH);
@@ -62,7 +62,7 @@ public class AndroidDeviceStorageInspectorTest {
 
     @Test
     public void returnsThePrimaryStorageApplicationPath() {
-        List<StoragePath> storagePaths = storageInspector.getPrimaryStorageApplicationPath();
+        List<StoragePath> storagePaths = storageInspector.getPrimaryStorageApplicationPaths();
 
         assertThat(storagePaths.size()).isEqualTo(1);
         assertThat(storagePaths.get(0)).isEqualTo(PRIMARY_APPLICATION_PATH);
@@ -74,7 +74,7 @@ public class AndroidDeviceStorageInspectorTest {
         givenDeviceCanReportExternalFileDirectories();
         givenExternalFileDirectoriesWillReturnPaths(SECONDARY_BASE_PATH_1);
 
-        List<StoragePath> storagePaths = storageInspector.getSecondaryStorageBasePath();
+        List<StoragePath> storagePaths = storageInspector.getSecondaryStorageBasePaths();
 
         assertThat(storagePaths.size()).isEqualTo(1);
         assertThat(storagePaths.get(0)).isEqualTo(SECONDARY_BASE_PATH_1);
@@ -86,7 +86,7 @@ public class AndroidDeviceStorageInspectorTest {
         givenFileSystemHasPath(SECONDARY_APPLICATION_PATH_1);
         givenExternalFileDirectoriesWillReturnPaths(SECONDARY_APPLICATION_PATH_1);
 
-        List<StoragePath> storagePaths = storageInspector.getSecondaryStorageApplicationPath();
+        List<StoragePath> storagePaths = storageInspector.getSecondaryStorageApplicationPaths();
 
         assertThat(storagePaths.size()).isEqualTo(1);
         assertThat(storagePaths.get(0)).isEqualTo(SECONDARY_APPLICATION_PATH_1);
@@ -96,7 +96,7 @@ public class AndroidDeviceStorageInspectorTest {
     public void returnsASecondaryStorageBasePathFromTheEnvironmentVariableInspector() {
         givenFileSystemHasPath(SECONDARY_BASE_PATH_1);
 
-        List<StoragePath> storagePaths = storageInspector.getSecondaryStorageBasePath();
+        List<StoragePath> storagePaths = storageInspector.getSecondaryStorageBasePaths();
 
         assertThat(storagePaths.size()).isEqualTo(1);
         assertThat(storagePaths.get(0)).isEqualTo(SECONDARY_BASE_PATH_1);
@@ -106,7 +106,7 @@ public class AndroidDeviceStorageInspectorTest {
     public void returnsNoSecondaryStorageApplicationPathFromTheEnvironmentVariableInspector() {
         givenFileSystemHasPath(SECONDARY_APPLICATION_PATH_1);
 
-        List<StoragePath> storagePaths = storageInspector.getSecondaryStorageApplicationPath();
+        List<StoragePath> storagePaths = storageInspector.getSecondaryStorageApplicationPaths();
 
         assertThat(storagePaths.size()).isEqualTo(0);
     }
@@ -119,7 +119,7 @@ public class AndroidDeviceStorageInspectorTest {
         givenDeviceCanReportExternalFileDirectories();
         givenExternalFileDirectoriesWillReturnPaths(SECONDARY_BASE_PATH_1, SECONDARY_BASE_PATH_2);
 
-        List<StoragePath> storagePaths = storageInspector.getSecondaryStorageBasePath();
+        List<StoragePath> storagePaths = storageInspector.getSecondaryStorageBasePaths();
 
         assertThat(storagePaths.size()).isEqualTo(2);
         assertThat(storagePaths.contains(SECONDARY_BASE_PATH_1)).isEqualTo(true);

--- a/library/src/test/java/com/novoda/storagepathfinder/ExternalFileDirectoryInspectorTest.java
+++ b/library/src/test/java/com/novoda/storagepathfinder/ExternalFileDirectoryInspectorTest.java
@@ -3,6 +3,7 @@ package com.novoda.storagepathfinder;
 import android.content.Context;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Before;
@@ -15,8 +16,7 @@ import static org.mockito.Mockito.mock;
 
 public class ExternalFileDirectoryInspectorTest {
 
-    private static final String PRIMARY_STORAGE_BASE_PATH_STRING = "/primary-storage-base-path";
-    private static final StoragePath PRIMARY_STORAGE_BASE_PATH = DeviceStoragePath.create(PRIMARY_STORAGE_BASE_PATH_STRING, PRIMARY);
+    private static final StoragePath PRIMARY_STORAGE_BASE_PATH = DeviceStoragePath.create("/primary-storage-base-path", PRIMARY);
     private static final StoragePath.Type SECONDARY = StoragePath.Type.SECONDARY;
     private static final StoragePath SECONDARY_BATH_PATH_1 = DeviceStoragePath.create("secondary-base-path-1", SECONDARY);
     private static final StoragePath SECONDARY_APPLICATION_PATH_1 = DeviceStoragePath.create("secondary-appplication-path-1", SECONDARY);
@@ -28,7 +28,8 @@ public class ExternalFileDirectoryInspectorTest {
 
     @Before
     public void setUp() {
-        inspector = new ExternalFileDirectoryInspector(context, deviceFeatures, PRIMARY_STORAGE_BASE_PATH_STRING);
+        List<StoragePath> primaryStoragePaths = Collections.singletonList(PRIMARY_STORAGE_BASE_PATH);
+        inspector = new ExternalFileDirectoryInspector(context, deviceFeatures, primaryStoragePaths);
     }
 
     @Test


### PR DESCRIPTION
## Problem
We've noticed some crashes on API 16 devices when the SD card is shown as unmounted in the storage settings 😬 

`ContextCompat.getExternalFilesDirs(context, null)[0];` calls down to `new File[] { context.getExternalFilesDir(type) };` which can be `null` when the shared storage is not available. 

Confusingly it seems that on earlier versions of android this shared storage is flagged as SD card storage even when there might not be an SD card involved 🤦‍♂️ 

## Solution
Highlight that `AndroidExternalStorageDirectories.getExternalStorageDirectoryApplicationPath` can be `Nullable`. Have the `ExternalDirectoryPrimaryStorageInspector` return `List<StoragePath>` where a `null` will return an `emptyList`.

## Screen Capture

API 16 | API 19
--- | ---
![api_16](https://user-images.githubusercontent.com/3380092/43709120-efd4e00a-9963-11e8-8d57-08cf5bbec17c.png) | ![api_19](https://user-images.githubusercontent.com/3380092/43709119-efac60bc-9963-11e8-8cc4-dc1cfcf432b4.png)


## Additional

This potentially leads to the issue where API 18 and below devices do not show a primary storage application path. I think this is probably because we should be looking for an external (shared) and internal (private) path rather than just looking for the external (shared). This will need some investigation 😬 